### PR TITLE
Add Ideas blog to whitelist

### DIFF
--- a/spec/helpers/view_helpers_spec.rb
+++ b/spec/helpers/view_helpers_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CrushinatorHelpers::ViewHelpers, type: :helper do
         allow(controller.request).to receive(:ssl?).and_return(true)
       end
 
-      %w(assets.tedcdn.com images.ted.com s3.amazonaws.com storage.ted.com tedlive.ted.com tedlive-staging.ted.com).each do |proxied|
+      %w(assets.tedcdn.com images.ted.com s3.amazonaws.com storage.ted.com tedconfblog.files.wordpress.com tedideas.files.wordpress.com tedlive.ted.com tedlive-staging.ted.com).each do |proxied|
         it "should add ssl prefix and suffix for #{proxied}" do
           expect(helper.crushinate \
             "http://#{proxied}#{path}"


### PR DESCRIPTION
Acknowledge `tedideas.files.wordpress.com` having been added to Crushinator's whitelist to address tedconf/roadrunner#3045.

See also: tedconf/crushinator#39