### PR TITLE
Don't crush *.svg URLs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,9 +9,6 @@ AllCops:
     - 'data/docker_images/purger/notifier_client/**/*'
     - 'data/docker_images/logstash/spec/logstash/*'
 
-Rails:
-  Enabled: false
-
 Style/NumericPredicate:
   Enabled: false
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -24,7 +24,7 @@ Layout/ExtraSpacing:
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles, IndentationWidth.
 # SupportedStyles: consistent, special_for_inner_method_call, special_for_inner_method_call_in_parentheses
-Layout/FirstParameterIndentation:
+Layout/IndentFirstArgument:
   Exclude:
     - 'spec/helpers/view_helpers_spec.rb'
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -119,12 +119,6 @@ Metrics/MethodLength:
 Metrics/PerceivedComplexity:
   Max: 9
 
-# Offense count: 3
-# Cop supports --auto-correct.
-Performance/RedundantMatch:
-  Exclude:
-    - 'app/helpers/crushinator_helpers/view_helpers.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 Security/YAMLLoad:

--- a/app/helpers/crushinator_helpers/view_helpers.rb
+++ b/app/helpers/crushinator_helpers/view_helpers.rb
@@ -32,7 +32,7 @@ module CrushinatorHelpers
           url = "#{match_data[1]}//#{match_data[2]}"
         end
 
-        if is_valid_domain?(url) && valid_options?(options)
+        if is_valid_domain?(url) && is_valid_extension?(url) && valid_options?(options)
           url = url.gsub(/.*\/\//, '')
           "https://pi.tedcdn.com/r/#{url}?#{options.to_query}"
         else
@@ -57,6 +57,10 @@ module CrushinatorHelpers
       ]
 
       image_hosts.any? { |host| url.match(host) }
+    end
+
+    def is_valid_extension?(url)
+      File.extname(URI(url).path) != '.svg'
     end
 
     # Look up the validation rule from validations.yml

--- a/spec/helpers/view_helpers_spec.rb
+++ b/spec/helpers/view_helpers_spec.rb
@@ -126,6 +126,11 @@ RSpec.describe CrushinatorHelpers::ViewHelpers, type: :helper do
       )
     end
 
+    it 'should reject URLs that are for svgs' do # & other extensions in the future?
+      expect(helper.crushinate('http://avatars.ted.com/1234.svg'))
+        .to eq('http://avatars.ted.com/1234.svg')
+    end
+
     describe "param validations" do
       validations = HashWithIndifferentAccess.new(YAML.load(File.read(File.expand_path('../../../config/validations.yml', __FILE__))))
       validations.each do |v|


### PR DESCRIPTION
This is:
* to match the js crushinators (see @redoPop's [assertion](https://github.com/tedconf/js-crushinator-helpers/commit/a252854e0d696e5934b307771be76f1645635133) to prove that behavior)
* to let us serve [our new generated avatars](https://github.com/tedconf/avatars) w/o pestering crushinator

I also fixed up some rubocop warnings (the tool itself, not the code).